### PR TITLE
Prevented clicking next before giving address

### DIFF
--- a/app/css/style_new.css
+++ b/app/css/style_new.css
@@ -92,6 +92,10 @@ a:hover, a:focus {
   color: #fff;
   outline: 0;
 }
+.btn[disabled] {
+  pointer-events: none;
+  opacity: 0.5;
+}
 .btn-blue {
   background-color: #2683ff;
   border-color: #2683ff;

--- a/app/views/share-wizard/wizard1.js
+++ b/app/views/share-wizard/wizard1.js
@@ -33,7 +33,7 @@ module.exports = {
     <div class="row text-center mb-4 mt-3">
       <div class="col-12">
         <input v-model="config.paymentAddress" type="text" class="address" placeholder="14Je4RQ6cYjytiv4fapajsEar4Gk3L4PAv">
-        <router-link :to="{path: '/share-wizard/wizard2'}" class="btn">Next</router-link>
+        <router-link :to="{path: '/share-wizard/wizard2'}" class="btn" :disabled="config.paymentAddress.length === 0">Next</router-link>
       </div>
     </div>
     <div class="row text-center">


### PR DESCRIPTION
*In reference to issue #540*

Adds a conditional to the anchor element to add a `disabled` attribute to the element when the address input box is empty. Also adds a css rule for `.btn[disabled]` because `a` elements don't do anything naturally when made disabled. The css attribute changes the button to 50% opacity and prevents clicking on it from doing anything.