### PR TITLE
Add snap install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,13 @@ Quick Start
 -----------
 
 If you wish only to run the application, download a pre-built release from our
-[releases page](https://github.com/Storj/storjshare-gui/releases). If you wish
-to build from source, follow the instructions below.
+[releases page](https://github.com/Storj/storjshare-gui/releases) or install storjshare-gui in seconds on [Ubuntu and other snap supported Linux distributions](https://snapcraft.io/docs/core/install) with:
+
+    snap install storjshare-gui --beta
+
+Installing a snap is very quick. Snaps are secure. They are isolated with all of their dependencies. Snaps also auto update when a new version is released.
+
+If you wish to build from source, follow the instructions below.
 
 ### Prerequisites
 


### PR DESCRIPTION
This pull request adds installation instructions for users of [snap enabled Linux distributions](https://snapcraft.io/docs/core/install). Snaps enable ISVs and projects to make their software available to millions of Linux users via the snap store and directly control delivery of software updates to their users. Snaps of stable desktop applications will also be available via the desktop Software Center, improving the discoverability of your software. Your software can be installed with a simple `snap install storjshare-gui --beta` simplifying the installation instructions for your users.

Once the snap is released into the stable channel in the store, users no longer need to add the ```--beta``` and will appear in the desktop Software Center