### PR TITLE
[WIP] Add support for ETH addresses in wizard

### DIFF
--- a/app/css/style_new.css
+++ b/app/css/style_new.css
@@ -166,7 +166,7 @@ input:active, input:focus {
 }
 
 input.address {
-  min-width: 410px;
+  min-width: 500px;
 }
 input[type="file"] {
   letter-spacing: 0px;

--- a/app/lib/eth-address-check.js
+++ b/app/lib/eth-address-check.js
@@ -1,0 +1,21 @@
+module.exports = function(teststring){
+	if(typeof teststring != 'string') {
+		return false;
+	}
+	if(teststring.length !== 42) {
+		return false;
+	}
+	if(teststring.substring(0,2) !== '0x') {
+		return false;
+	}
+	//Check to make sure the string is valid hex
+	let hex = '0123456789abcdef';
+	let lowercase = teststring.toLowerCase().substring(2,42);
+	for(let i = 0; i < lowercase.length; i++) {
+		if(hex.indexOf(lowercase.substring(i,i+1)) < 0) {
+			return false;
+		}
+	}
+	//All clear
+	return true;
+}

--- a/app/views/share-wizard/wizard1.js
+++ b/app/views/share-wizard/wizard1.js
@@ -10,6 +10,11 @@ module.exports = {
   created: function() {
     this.actions.reset();
   },
+  mixins: [{
+    methods: {
+      checkEthereumAddress: require('../../lib/eth-address-check.js')
+    }
+  }],
   template: `
 <section>
   <div class="container">
@@ -35,8 +40,8 @@ module.exports = {
     </div>
     <div class="row text-center mb-4 mt-3">
       <div class="col-12">
-        <input v-model="config.paymentAddress" type="text" class="address" placeholder="14Je4RQ6cYjytiv4fapajsEar4Gk3L4PAv">
-        <router-link :to="{path: '/share-wizard/wizard2'}" class="btn" :disabled="config.paymentAddress.length === 0">Next</router-link>
+        <input v-model="config.paymentAddress" type="text" class="address" placeholder="0xETHEREUM_ADDRESS">
+        <router-link :to="{path: '/share-wizard/wizard2'}" class="btn" :disabled="!checkEthereumAddress(config.paymentAddress)">Next</router-link>
       </div>
     </div>
     <div class="row text-center">


### PR DESCRIPTION
This commit changes a few things to get closer to Ethereum support:

1. It replaces the placeholder text in the share setup wizard with `0xETHEREUM_ADDRESS_HERE`, to get the point across that the user should be entering an Ethereum address, not a Bitcoin one.

2. It widens the input box by a small margin so the entire address fits in the view

3. It checks the validity of the input and makes sure the user has entered a valid Ethereum address, otherwise they will not be able to continue.

This PR is designed to not be merged until the switch to Ethereum is made, as any attempt to input a Bitcoin address will fail.

_Hopefully this is the last time I have to make a new pull request, sorry. Trying to get git issues sorted out on my end._ 