### PR TITLE
Pre-fill address if share already exists

### DIFF
--- a/app/views/share-wizard/wizard1.js
+++ b/app/views/share-wizard/wizard1.js
@@ -1,4 +1,5 @@
 'use strict';
+
 module.exports = {
   data: function() {
     return window.Store.newShare;

--- a/app/views/share-wizard/wizard1.js
+++ b/app/views/share-wizard/wizard1.js
@@ -1,5 +1,4 @@
 'use strict';
-
 module.exports = {
   data: function() {
     return window.Store.newShare;
@@ -9,6 +8,10 @@ module.exports = {
   },
   created: function() {
     this.actions.reset();
+    //Pre-fill their first payment address if they already have a share
+    if(window.Store.shareList.shares.length > 0) {
+      this.$set(this.config, 'paymentAddress', window.Store.shareList.shares[0].config.paymentAddress);
+    }
   },
   template: `
 <section>


### PR DESCRIPTION
Fixes #576 

When going to the wizard, if a drive already exists it will pre-populate the address field with the user's address. The address from drive 0 is always used.