### PR TITLE
Add host step to wizard

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -31,6 +31,10 @@ module.exports = {
         {
           path: 'wizard5',
           component: require('./views/share-wizard/wizard5')
+        },
+        {
+          path: 'wizard6',
+          component: require('./views/share-wizard/wizard6')
         }
       ]
     },

--- a/app/views/share-wizard/wizard1.js
+++ b/app/views/share-wizard/wizard1.js
@@ -9,6 +9,12 @@ module.exports = {
   },
   created: function() {
     this.actions.reset();
+    //Set tunnel options to 0 to prepare for removal of tunneling
+    this.$set(this.config, 'maxTunnels', 0);
+    this.$set(this.config, 'tunnelGatewayRange', {
+      min: 0,
+      max: 0
+    });
     //Pre-fill their first payment address if they already have a share
     if(window.Store.shareList.shares.length > 0) {
       this.$set(this.config, 'paymentAddress', window.Store.shareList.shares[0].config.paymentAddress);
@@ -31,7 +37,7 @@ module.exports = {
         <span v-if="$route.query.edit"><router-link :to="{path: '/overview'}"><small>&lt; Go Back</small></router-link></span>
       </div>
       <div class="col-6 text-right">
-        <small>Step 1 of 3</small>
+        <small>Step 1 of 5</small>
       </div>
     </div>
     <div class="row">

--- a/app/views/share-wizard/wizard2.js
+++ b/app/views/share-wizard/wizard2.js
@@ -22,7 +22,7 @@ module.exports = {
         <router-link :to="{path: '/share-wizard/wizard1'}"><small>&lt; Go Back</small></router-link>
       </div>
       <div class="col-6 text-right">
-        <small>Step 2 of 3</small>
+        <small>Step 2 of 5</small>
       </div>
     </div>
     <div class="row">

--- a/app/views/share-wizard/wizard3.js
+++ b/app/views/share-wizard/wizard3.js
@@ -29,7 +29,7 @@ module.exports = {
         <router-link :to="{path: '/share-wizard/wizard2'}"><small>&lt; Go Back</small></router-link>
       </div>
       <div class="col-6 text-right">
-        <small>Step 3 of 3</small>
+        <small>Step 3 of 5</small>
       </div>
     </div>
     <div class="row">

--- a/app/views/share-wizard/wizard4.js
+++ b/app/views/share-wizard/wizard4.js
@@ -8,7 +8,6 @@ module.exports = {
       MAXPORTNUM: 65536,
       MINPORTNUM: 1024,
       uiState: {
-        isCreating: false,
         isChecking: false
       },
       invalidPort: {
@@ -38,7 +37,6 @@ module.exports = {
     },
     portIsAvailable: function(port, callback) {
       const utils = require('storjshare-daemon').utils;
-      console.dir(utils);
       return utils.portIsAvailable(port, callback);
     },
     checkPort: function() {
@@ -52,22 +50,10 @@ module.exports = {
           self.uiState.isChecking = false;
           self.continueButtonText = 'Next';
         } else {
-          self.saveToDisk();
+          self.uiState.isChecking = false;
+          return self.$router.push({ path: '/share-wizard/wizard5' });
         }
       });
-    },
-    saveToDisk: function() {
-      this.uiState.isCreating = true;
-      this.continueButtonText = 'Saving...';
-      let configPath = this.newShare.actions.createShareConfig();
-      if(configPath) {
-        this.shareList.actions.import(configPath, (err) => {
-          this.uiState.isCreating = false;
-          if(!err) {
-            return this.$router.push({ path: '/share-wizard/wizard5' });
-          }
-        });
-      }
     }
   },
   template: `
@@ -78,7 +64,7 @@ module.exports = {
         <router-link :to="{path: '/share-wizard/wizard3'}"><small>&lt; Go Back</small></router-link>
       </div>
       <div class="col-6 text-right">
-        <small>Step 4 of 4</small>
+        <small>Step 4 of 5</small>
       </div>
     </div>
     <div class="row">
@@ -107,7 +93,6 @@ module.exports = {
         </b-tooltip>
         <button v-on:click="chooseRandomPort" class="btn btn-secondary mr-3">Random</button>
         <button v-on:click="checkPort" class="btn" v-bind:disabled="uiState.isChecking">{{invalidPort.port === newShare.config.rpcPort ? 'Continue Anyways' : continueButtonText}}</button>
-        <img v-if="uiState.isCreating" class="loader"></img>
       </div>
     </div>
     <div class="row text-center">

--- a/app/views/share-wizard/wizard5.js
+++ b/app/views/share-wizard/wizard5.js
@@ -14,6 +14,10 @@ module.exports = {
     'ext-a' : require('../components/external-anchor')
   },
   created: function() {
+    //If the user has doNotTraverseNat set to false, skip this page to keep things simple
+    if(!this.newShare.config.doNotTraverseNat) {
+      return this.saveToDisk();
+    }
     //If the user already has a share, start out their address to be the one
     //they're currently using
     let numShares = this.shareList.shares.length;

--- a/app/views/share-wizard/wizard5.js
+++ b/app/views/share-wizard/wizard5.js
@@ -1,27 +1,68 @@
 'use strict';
 
 module.exports = {
+  data: function() {
+    return {
+      newShare: window.Store.newShare,
+      shareList: window.Store.shareList,
+      uiState: {
+        isCreating: false
+      }
+    }
+  },
+  components: {
+    'ext-a' : require('../components/external-anchor')
+  },
+  created: function() {
+    //If the user already has a share, start out their address to be the one
+    //they're currently using
+    let numShares = this.shareList.shares.length;
+    if(numShares > 0) {
+      this.newShare.config.rpcAddress = this.shareList.shares[numShares - 1].config.rpcAddress;
+    }
+  },
+  methods: {
+    saveToDisk: function() {
+      this.uiState.isCreating = true;
+      let configPath = this.newShare.actions.createShareConfig();
+      if(configPath) {
+        this.shareList.actions.import(configPath, (err) => {
+          this.uiState.isCreating = false;
+          if(!err) {
+            return this.$router.push({ path: '/share-wizard/wizard6' });
+          }
+        });
+      }
+    }
+  },
   template: `
 <section>
   <div class="container">
     <div class="row wizard-nav">
-      <div class="col-6 text-left">
-        <a href="https://storj.io/share.html"><small>Storj Share</small></a>
+      <div class="col-6">
+        <router-link :to="{path: '/share-wizard/wizard4'}"><small>&lt; Go Back</small></router-link>
       </div>
       <div class="col-6 text-right">
-        <small>Finished</small>
+        <small>Step 5 of 5</small>
       </div>
     </div>
-    <div class="row text-center">
+    <div class="row">
       <div class="col-12">
         <img src="imgs/logo.svg" alt="Storj Share" class="logo">
       </div>
     </div>
     <div class="row text-center">
       <div class="col-12">
-        <h2>You are amazing!</h2>
-        <p>You have successfully configured Storj Share. <br class="hidden-sm-down">Keep on sharing and earning STORJ. #BeTheCloud</p>
-        <router-link :to="{path: '/overview'}" class="btn mt-3">Finish</router-link>
+        <h2>Step 5 - Host Address</h2>
+        <p>Please enter your external public IP address or a valid hostname so that other nodes will be able to connect to you. It is recommended to use a hostname service like <ext-a href="https://www.noip.com/">No-IP</ext-a> if your external public IP address is not static.</p>
+        <p>If you don't know what your external public IP address is, use a site like <ext-a href="https://www.whatismyip.com/">whatismyip.com</ext-a>.</p>
+      </div>
+    </div>
+    <div class="row text-center mb-4 mt-3">
+      <div class="col-12">
+        <input v-model="newShare.config.rpcAddress" type="text" placeholder="127.0.0.1">
+        <button v-on:click="saveToDisk()" class="btn" :disabled="newShare.config.rpcAddress.length === 0">Next</button>
+        <img v-if="uiState.isCreating" class="loader"></img>
       </div>
     </div>
   </div>

--- a/app/views/share-wizard/wizard6.js
+++ b/app/views/share-wizard/wizard6.js
@@ -1,0 +1,30 @@
+'use strict';
+
+module.exports = {
+  template: `
+<section>
+  <div class="container">
+    <div class="row wizard-nav">
+      <div class="col-6 text-left">
+        <a href="https://storj.io/share.html"><small>Storj Share</small></a>
+      </div>
+      <div class="col-6 text-right">
+        <small>Finished</small>
+      </div>
+    </div>
+    <div class="row text-center">
+      <div class="col-12">
+        <img src="imgs/logo.svg" alt="Storj Share" class="logo">
+      </div>
+    </div>
+    <div class="row text-center">
+      <div class="col-12">
+        <h2>You are amazing!</h2>
+        <p>You have successfully configured Storj Share. <br class="hidden-sm-down">Keep on sharing and earning STORJ. #BeTheCloud</p>
+        <router-link :to="{path: '/overview'}" class="btn mt-3">Finish</router-link>
+      </div>
+    </div>
+  </div>
+</section>
+  `
+};


### PR DESCRIPTION
### Changes:

- Add new step to wizard to configure `rpcAddress`. Wizard will not take an empty string, and will autofill to the previously used `rpcAddress` in another config if available. Includes links to no-ip and whatismyip.com for inexperienced users.
- `maxTunnels`, and the `min` and `max` in the tunnel range will all now initialize to 0. This is in preparation for tunneling no longer being a part of the protocol.
- Fixed page numbering to reflect the new step.

- [x] Closes #517

![Image 1](https://i.imgur.com/jKHD60v.png)
![Image 2](https://i.imgur.com/2kIApvX.png)