### PR TITLE
Crucial line missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ Quick Start
 -----------
 
 If you wish only to run the application, download a pre-built release from our
-[releases page](https://github.com/Storj/storjshare-gui/releases) or install storjshare-gui in seconds on [Ubuntu and other snap supported Linux distributions](https://snapcraft.io/docs/core/install) with:
+[releases page](https://github.com/Storj/storjshare-gui/releases) or use snapd to install storjshare-gui in seconds on [Ubuntu and other snap supported Linux distributions](https://snapcraft.io/docs/core/install) with:
 
+
+    snap download storjshare-gui --beta
     snap install storjshare-gui --beta
 
 Installing a snap is very quick. Snaps are secure. They are isolated with all of their dependencies. Snaps also auto update when a new version is released.


### PR DESCRIPTION
People who haven't used snaps before might be mystified as to why the command doesn't work at first. You have to acquire the snap before snapd will let you install it, of course. I had never used snaps for anything before, but had used Appimage. After a bit I figured it out, but this quick addition to the Readme should save others the bit.