### PR TITLE
Re-insert comments into configuration file

### DIFF
--- a/app/stores/share.js
+++ b/app/stores/share.js
@@ -81,13 +81,11 @@ class Share {
 
       // Restores comments
       for (let i = 0; i < defaultConfigArray.length - 1; i++, rawConfigIndex++){
-        let commentIndex = defaultConfigArray[i].indexOf("/");
-        if(defaultConfigArray[i].charAt(commentIndex) == defaultConfigArray[i].charAt(commentIndex + 1)
-          && defaultConfigArray[i].trim().startsWith("/")){
+        if(defaultConfigArray[i].includes("//") && defaultConfigArray[i].trim().startsWith("/")){
           configArray.splice(rawConfigIndex,0,defaultConfigArray[i]);
         }
       }
-      
+
       let configBuffer = Buffer.from(configArray.join("\n"));
 
       try {

--- a/app/stores/share.js
+++ b/app/stores/share.js
@@ -75,9 +75,23 @@ class Share {
       this.config.loggerOutputFile = logPath;
       configPath = path.join(configPath, '/') + nodeID + '.json';
 
-      let configBuffer = Buffer.from(
-        JSON.stringify(this.config, null, 2)
-      );
+      let configArray = JSON.stringify(this.config, null, 2).split("\n");
+      let defaultConfigArray = defaultConfig.split("\n");
+      let rawConfigIndex = 0;
+      console.log(JSON.stringify(this.config,null,2).split("\n"));
+      console.log(configArray);
+
+      // Restores comments
+      for (let i = 0; i < defaultConfigArray.length - 1; i++, rawConfigIndex++){
+        let commentIndex = defaultConfigArray[i].indexOf("/");
+        if(defaultConfigArray[i].charAt(commentIndex) == defaultConfigArray[i].charAt(commentIndex + 1)
+          && defaultConfigArray[i].trim().startsWith("/")){
+          configArray.splice(rawConfigIndex,0,defaultConfigArray[i]);
+        }
+        console.log(configArray[i]);
+      }
+      console.log(configArray.toString());
+      let configBuffer = Buffer.from(configArray.join("\n"));
 
       try {
         storjshare.utils.validate(this.config);

--- a/app/stores/share.js
+++ b/app/stores/share.js
@@ -78,8 +78,6 @@ class Share {
       let configArray = JSON.stringify(this.config, null, 2).split("\n");
       let defaultConfigArray = defaultConfig.split("\n");
       let rawConfigIndex = 0;
-      console.log(JSON.stringify(this.config,null,2).split("\n"));
-      console.log(configArray);
 
       // Restores comments
       for (let i = 0; i < defaultConfigArray.length - 1; i++, rawConfigIndex++){
@@ -88,9 +86,8 @@ class Share {
           && defaultConfigArray[i].trim().startsWith("/")){
           configArray.splice(rawConfigIndex,0,defaultConfigArray[i]);
         }
-        console.log(configArray[i]);
       }
-      console.log(configArray.toString());
+      
       let configBuffer = Buffer.from(configArray.join("\n"));
 
       try {

--- a/app/stores/share.js
+++ b/app/stores/share.js
@@ -81,8 +81,8 @@ class Share {
 
       // Restores comments
       for (let i = 0; i < defaultConfigArray.length - 1; i++, rawConfigIndex++){
-        if(defaultConfigArray[i].includes("//") && defaultConfigArray[i].trim().startsWith("/")){
-          configArray.splice(rawConfigIndex,0,defaultConfigArray[i]);
+        if(defaultConfigArray[i].trim().startsWith("//")){
+          configArray.splice(rawConfigIndex, 0, defaultConfigArray[i]);
         }
       }
 


### PR DESCRIPTION
This restores comments into the configuration file for nodes when created. I talked to @littleskunk about implementing a migration feature to update existing configuration files, but he noted that the risk may be greater than the reward.

Fixes #631 

A basic explanation of the code:
We loop through all lines of the defaultConfig `schema.json` file.
If the string `//` exists at the beginning of the line then insert the comment into the configuration file