### PR TITLE
Update "How to create a wallet" link

### DIFF
--- a/app/views/share-wizard/wizard1.js
+++ b/app/views/share-wizard/wizard1.js
@@ -58,7 +58,7 @@ module.exports = {
     </div>
     <div class="row text-center">
       <div class="col-12">
-        <small><ext-a href="https://storj.io/share.html#faq-1-3">How to create a wallet?</ext-a> &middot; <ext-a href="https://storj.io/share.html#faq-1-4">Where do I find the address?</ext-a></small>
+        <small><ext-a href="https://docs.storj.io/docs/storj-share-gui#section--wallet-address-">How to create a wallet?</ext-a> &middot; <ext-a href="https://storj.io/share.html#faq-1-4">Where do I find the address?</ext-a></small>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Link to "https://storj.io/share.html#faq-1-3" does not lead to an actual faq entry.
Change to wallet address link in docs.storj.io "https://docs.storj.io/docs/storj-share-gui#section--wallet-address-"