### PR TITLE
Removed '#' from overview index column

### DIFF
--- a/app/views/overview/index.js
+++ b/app/views/overview/index.js
@@ -109,7 +109,7 @@ module.exports = {
                     class="checkbox">
                 </td>
 
-                <td><span>#{{index}}</span></td>
+                <td><span>{{index}}</span></td>
 
 		<td><b-tooltip content="The Node ID of the node."><span>{{share.id}}</span></b-tooltip></td>
 


### PR DESCRIPTION
Reference: #727 

I removed the pound sign(#) from the overview index column. 

Seems like it might be there for legibility.

But if you want it..here it is.

![2017-10-29_23-21-22](https://user-images.githubusercontent.com/10393491/32157312-edf1d8f6-bcff-11e7-8ed0-80e4792cbd94.png)
